### PR TITLE
Linkercommon

### DIFF
--- a/linker_common.R
+++ b/linker_common.R
@@ -2,5 +2,14 @@
 #' @param linkerSequence, vector of linker sequences
 #' @return linkerCommon, vector of the sequence after N
 linker_common <- function(linkerSequence) {
-    return(linkerSequence)
+    stopifnot(require("Biostrings"))
+    splited <- strsplit(linkerSequence, 'N+')
+    stopifnot(sapply(splited, length) == 2)
+    afterN <- sapply(splited, "[[", 2)
+    stopifnot(length(afterN)==length(linkerSequence))
+    
+    afterN_RCed <- unlist(lapply(afterN, function(x) as.character(reverseComplement(DNAString(x)))))
+    stopifnot(length(afterN_RCed)==length(linkerSequence))
+    
+    return(afterN_RCed)
 }

--- a/linker_common.R
+++ b/linker_common.R
@@ -1,38 +1,34 @@
 #' Extract the second part of sequence of the linker sequence and
 #' reverse complement; in case a linker has no N in the middle,
-#' get the last 15 bases and reverse complement.
+#' get the last min_len bases and reverse complement.
 #' @param linkerSequence, vector of linker sequences
+#' @param min_len length of linker for the case of no N
+#'    (with N minumum linker accepted as valid)
 #' @return linkerCommon, vector of the sequence after N
-linker_common <- function(linkerSequence) {
-    stopifnot(require("Biostrings"))
-    stopifnot(is.character(linkerSequence))
+linker_common <- function(linkerSequence, min_len=15) {
+    stopifnot(require("Biostrings")) # should we test for libraries presence?
+    stopifnot(is.character(linkerSequence)) # should we check types of args?
     splited <- strsplit(linkerSequence, 'N+')
     
     splited.len <- sapply(splited, length)
     stopifnot( all(splited.len == 2 | splited.len == 1))
     
-    afterN_RCed <- lapply(splited, function(x) {
+    common_seq <- sapply(splited, function(x) {
         ## linker with continuous N in the middle
-        if ( length(x)==2 ) return(as.character(reverseComplement(DNAString(x[2])))) 
+        if ( length(x)==2 ) 
+            return(.get_rev_seq(x[2]))
         ## linker with no N in the middle
         if ( length(x)==1 ) {
-            if( nchar(x)<=15 ) stop("Linker should always longer than 15 bases")
-            last15 <- substr(x, nchar(x)-15+1, nchar(x))
-            return(as.character(reverseComplement(DNAString(last15)))) 
+            if( nchar(x) <= min_len ) stop(
+                paste("Linker should always longer than", min_len, " bases"))
+            last_seq <- substr(x, nchar(x)-min_len+1, nchar(x))
+            return(.get_rev_seq(last_seq))
         }
-        
-        ## seperated N, this situation should not happen
-        stop("Unknow situation:", paste(x, collapse=" "))
     })
-    afterN_RCed <- unlist(afterN_RCed)
-    
-    stopifnot(length(afterN_RCed)==length(linkerSequence))
-    stopifnot(nchar(afterN_RCed)>=15)
-    
-    return(afterN_RCed)
+    stopifnot(nchar(common_seq)>=min_len) # small linkers are not used in prep
+    return(common_seq)
 }
 
-
-
-
-
+.get_rev_seq <- function(seq) {
+    as.character(reverseComplement(DNAString(seq)))
+}

--- a/linker_common.R
+++ b/linker_common.R
@@ -1,0 +1,6 @@
+#' extract the second part of sequence of the linker sequence
+#' @param linkerSequence, vector of linker sequences
+#' @return linkerCommon, vector of the sequence after N
+linker_common <- function(linkerSequence) {
+    return(linkerSequence)
+}

--- a/linker_common.R
+++ b/linker_common.R
@@ -3,6 +3,7 @@
 #' @return linkerCommon, vector of the sequence after N
 linker_common <- function(linkerSequence) {
     stopifnot(require("Biostrings"))
+    stopifnot(is.character(linkerSequence))
     splited <- strsplit(linkerSequence, 'N+')
     stopifnot(sapply(splited, length) == 2)
     afterN <- sapply(splited, "[[", 2)

--- a/linker_common.R
+++ b/linker_common.R
@@ -1,16 +1,38 @@
-#' extract the second part of sequence of the linker sequence
+#' Extract the second part of sequence of the linker sequence and
+#' reverse complement; in case a linker has no N in the middle,
+#' get the last 15 bases and reverse complement.
 #' @param linkerSequence, vector of linker sequences
 #' @return linkerCommon, vector of the sequence after N
 linker_common <- function(linkerSequence) {
     stopifnot(require("Biostrings"))
     stopifnot(is.character(linkerSequence))
     splited <- strsplit(linkerSequence, 'N+')
-    stopifnot(sapply(splited, length) == 2)
-    afterN <- sapply(splited, "[[", 2)
-    stopifnot(length(afterN)==length(linkerSequence))
     
-    afterN_RCed <- unlist(lapply(afterN, function(x) as.character(reverseComplement(DNAString(x)))))
+    splited.len <- sapply(splited, length)
+    stopifnot( all(splited.len == 2 | splited.len == 1))
+    
+    afterN_RCed <- lapply(splited, function(x) {
+        ## linker with continuous N in the middle
+        if ( length(x)==2 ) return(as.character(reverseComplement(DNAString(x[2])))) 
+        ## linker with no N in the middle
+        if ( length(x)==1 ) {
+            if( nchar(x)<=15 ) stop("Linker should always longer than 15 bases")
+            last15 <- substr(x, nchar(x)-15+1, nchar(x))
+            return(as.character(reverseComplement(DNAString(last15)))) 
+        }
+        
+        ## seperated N, this situation should not happen
+        stop("Unknow situation:", paste(x, collapse=" "))
+    })
+    afterN_RCed <- unlist(afterN_RCed)
+    
     stopifnot(length(afterN_RCed)==length(linkerSequence))
+    stopifnot(nchar(afterN_RCed)>=15)
     
     return(afterN_RCed)
 }
+
+
+
+
+

--- a/tests/test_calculate_linker_common.R
+++ b/tests/test_calculate_linker_common.R
@@ -1,0 +1,24 @@
+library(testthat)
+source("../linker_common.R")
+
+linker_input <- c(
+    "CGCCAACGTAGCGTTGCACNNNNNNNNNNNNCTCCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT"
+    )
+
+expected_linker_common_output <- c("AGTCCCTTAAGCGGAG", "AGTCCCTTAAGCGGAG")
+
+test_that("Second sequence after N", {
+    expect_equal(expected_linker_common_output, linker_common(linker_input) )
+})
+
+
+linker_noN_input <- c(
+    "CGCCAACGTAGCGTTGCACCTCCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT"
+    )
+
+test_that("Fail if no N in the middle", {
+    expect_error(linker_common(linker_noN_input))
+})
+

--- a/tests/test_calculate_linker_common.R
+++ b/tests/test_calculate_linker_common.R
@@ -17,19 +17,39 @@ test_that("Reverse complement of the sequence after N, vector of length 1", {
 })
 
 
-linker_noN_input <- c(
+linker_input <- c(
     "CGCCAACGTAGCGTTGCACCTCCGCTTAAGGGACT",
     "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
 
-test_that("Fail if no N in the middle", {
-    expect_error(linker_common(linker_noN_input))
+expected_linker_common_output <- c("AGTCCCTTAAGCGGA", "AGTCCCTTAAGCGGA")
+
+test_that("Linker with no N", {
+    expect_equal(expected_linker_common_output, linker_common(linker_input) )
 })
 
-linker_moreN_input <- c(
+
+linker_input <- c(
+    "CGCCAACGTAGCGTTGCACNNNNNNNNNNNNCTCCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT",
+    "CGCCAACGTAGCGTTGCACCTCCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
+
+expected_linker_common_output <- c(
+    "AGTCCCTTAAGCGGAG",
+    "AGTCCCTTAAGCGGAG",
+    "AGTCCCTTAAGCGGA",
+    "AGTCCCTTAAGCGGA")
+
+test_that("Mixed kinds of linkers", {
+    expect_equal(expected_linker_common_output, linker_common(linker_input) )
+})
+
+
+linker_input <- c(
     "CGCCAACGTAGCGNNNTTGCACCTCNCGCTTAAGGGACT",
     "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
 
-test_that("Fail if more N in the middle", {
-    expect_error(linker_common(linker_noN_input))
+test_that("Should fail if seperated N's in the middle", {
+    expect_error(linker_common(linker_input))
 })
 

--- a/tests/test_calculate_linker_common.R
+++ b/tests/test_calculate_linker_common.R
@@ -3,22 +3,33 @@ source("../linker_common.R")
 
 linker_input <- c(
     "CGCCAACGTAGCGTTGCACNNNNNNNNNNNNCTCCGCTTAAGGGACT",
-    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT"
-    )
+    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT" )
+    
 
 expected_linker_common_output <- c("AGTCCCTTAAGCGGAG", "AGTCCCTTAAGCGGAG")
 
-test_that("Second sequence after N", {
+test_that("Reverse complement of the sequence after N", {
     expect_equal(expected_linker_common_output, linker_common(linker_input) )
+})
+
+test_that("Reverse complement of the sequence after N, vector of length 1", {
+    expect_equal(expected_linker_common_output[1], linker_common(linker_input[1]) )
 })
 
 
 linker_noN_input <- c(
     "CGCCAACGTAGCGTTGCACCTCCGCTTAAGGGACT",
-    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT"
-    )
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
 
 test_that("Fail if no N in the middle", {
+    expect_error(linker_common(linker_noN_input))
+})
+
+linker_moreN_input <- c(
+    "CGCCAACGTAGCGNNNTTGCACCTCNCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
+
+test_that("Fail if more N in the middle", {
     expect_error(linker_common(linker_noN_input))
 })
 


### PR DESCRIPTION
Added function linker_common(). It grabs the sequence after N from the linker sequences, and then reverse complement them. Unit tests tested some exceptions and the accuracy of the function. The test linker sequences and the corresponding expected output sequences were taken from the sampleInfo.csv and processingParams.csv files.  
