### PR TITLE
Additional checks for read pairing

### DIFF
--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -567,11 +567,13 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
   strand(properlyPairedAlignments) <- strand(R2s)
 
   #need to kick out properlyPaired Alignments that are 'outward facing'
-  #these will have union widths that are far greater than the reduction widths
-  unionWidths <- width(punion(R1s, R2s, ignore.strand=T, fill.gap=T))
-
-  properlyPairedAlignments <- properlyPairedAlignments[abs(unionWidths-width(properlyPairedAlignments)) < 5]
-
+  #therefore the beginning of R1 should always be 
+  #downstream of the beginning of R2
+  R1Starts <- start(flank(R1s, -1, start = TRUE))
+  R2Starts <- start(flank(R2s, -1, start = TRUE))
+  isDownstream <- ifelse(strand(R2s) == "+", R1Starts > R2Starts, R1Starts < R2Starts)
+  properlyPairedAlignments <- properlyPairedAlignments[isDownstream]
+  
   numProperlyPairedAlignments <- length(unique(names(properlyPairedAlignments)))
 
   stats <- cbind(stats, numProperlyPairedAlignments)

--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -572,7 +572,8 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
   R1Starts <- start(flank(R1s, -1, start = TRUE))
   R2Starts <- start(flank(R2s, -1, start = TRUE))
   isDownstream <- ifelse(strand(R2s) == "+", R1Starts > R2Starts, R1Starts < R2Starts)
-  properlyPairedAlignments <- properlyPairedAlignments[isDownstream]
+  isOppositeStrand <- !strand(R2s) == strand(R1s)
+  properlyPairedAlignments <- properlyPairedAlignments[isDownstream & isOppositeStrand]
   
   numProperlyPairedAlignments <- length(unique(names(properlyPairedAlignments)))
 


### PR DESCRIPTION
Removes old test (union vs. reduce) and implemented a check to make sure that the R1 start is downstream of the R2 start as well as checking to make sure R1 and R2 are on opposite strands.
