### PR TITLE
Trim and align fix

### DIFF
--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -172,7 +172,7 @@ trim_Ltr_side_reads <- function(reads.p, primer, ltrbit, maxMisMatch=0) {
                                gapOpening = 0,
                                gapExtension = 1,
                                type="overlap")
-    aln.l.df <- PairwiseAlignmentsSingleSubject2DF(aln.l, shift=nchar(primer)-1)
+    aln.l.df <- PairwiseAlignmentsSingleSubject2DF(aln.l, shift=nchar(primer))
     
     goodIdx <- (aln.p.df$score >= nchar(primer)-maxMisMatch &
                 aln.l.df$score >= nchar(ltrbit)-maxMisMatch)
@@ -473,7 +473,13 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
     algns$from <- from
     algns <- merge(algns, keys[c(from, "names")], by.x="qName", by.y=from)
     algns.gr <- GRanges(seqnames=Rle(algns$tName),
-                        ranges=IRanges(start=algns$tStart, end=algns$tEnd),
+                        ranges = ifelse(algns$strand == "+",
+                          IRanges(
+                            start = (algns$tStart - algns$qStart + 1),
+                            end = (algns$end + (algns$qSize - algns$qEnd))),
+                          IRanges(
+                            start = (algns$tStart - (algns$qSize - algns$qEnd)),
+                            end = (algns$tEnd + algns$qStart - 1))),
                         strand=Rle(algns$strand),
                         seqinfo=seqinfo(get_reference_genome(refGenome)))
     

--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -475,10 +475,10 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
     algns$qtStart <- ifelse(
       algns$strand == "+",
       (algns$tStart - (algns$qStart)),
-      (algns$tStart - (algns$qSize - algns$qEnd)))
+      (algns$tStart - (algns$qSize - algns$qEnd + 1)))
     algns$qtEnd <- ifelse(
       algns$strand == "+",
-      (algns$tEnd + (algns$qSize - algns$qEnd)),
+      (algns$tEnd + (algns$qSize - algns$qEnd - 1)),
       (algns$tEnd + (algns$qStart)))    
     
     algns.gr <- GRanges(seqnames=Rle(algns$tName),

--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -476,7 +476,7 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
                         ranges = ifelse(algns$strand == "+",
                           IRanges(
                             start = (algns$tStart - algns$qStart + 1),
-                            end = (algns$end + (algns$qSize - algns$qEnd))),
+                            end = (algns$tEnd + (algns$qSize - algns$qEnd))),
                           IRanges(
                             start = (algns$tStart - (algns$qSize - algns$qEnd)),
                             end = (algns$tEnd + algns$qStart - 1))),

--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -482,7 +482,7 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
       (algns$tEnd + (algns$qStart)))    
     
     algns.gr <- GRanges(seqnames=Rle(algns$tName),
-                        ranges = IRanges(start = (algns$qtStart + 1), width = algns$qSize), #Convert to 1-base
+                        ranges = IRanges(start = (algns$qtStart + 1), end = (algns$qtEnd)), #Convert to 1-base
                         strand=Rle(algns$strand),
                         seqinfo=seqinfo(get_reference_genome(refGenome)))
     

--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -475,7 +475,7 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
     algns$qtStart <- ifelse(
       algns$strand == "+",
       (algns$tStart - (algns$qStart)),
-      (algns$tStart - (algns$qSize - algns$qEnd + 1)))
+      (algns$tStart - (algns$qSize - algns$qEnd - 1)))
     algns$qtEnd <- ifelse(
       algns$strand == "+",
       (algns$tEnd + (algns$qSize - algns$qEnd - 1)),

--- a/intSiteLogic.R
+++ b/intSiteLogic.R
@@ -482,7 +482,7 @@ processAlignments <- function(workingDir, minPercentIdentity, maxAlignStart, max
       (algns$tEnd + (algns$qStart)))    
     
     algns.gr <- GRanges(seqnames=Rle(algns$tName),
-                        ranges = IRanges(start = (algns$qtStart + 1), end = (algns$qtEnd + 1)), #Convert to 1-base
+                        ranges = IRanges(start = (algns$qtStart + 1), width = algns$qSize), #Convert to 1-base
                         strand=Rle(algns$strand),
                         seqinfo=seqinfo(get_reference_genome(refGenome)))
     


### PR DESCRIPTION
These changes correct two minor but important problems that were discovered in the pipeline.

First, there is a minor fix to the R2 trimming. Previously, the trimming was leaving the terminal "A" nucleotide from the LTR on the reads. The trimming distance was corrected to remove this nucleotide.

Second, when calling integration sites and breakpoints, the code used the range of the alignment between the R1/2 read and the reference genome. This works in the majority of cases, but when single or double mismatches occur at the edges of the read, these portions will not be included in the alignment range but still pass the quality filters. This lead to calling positions of integration sites and breakpoints to "drift" as more and more reads were aligned with a minor fraction of sequencing error or mismatches. This behavior was corrected to instead account for the number of nucleotides present in the read that may have not aligned to the genome. These mismatches are still considered in the quality filters, as they were previously.

Outcomes of these modifications have shows better alignments to the reference genome and more precise calling integration sites and breakpoints from control and test specimens.  